### PR TITLE
Use new mpy_ld.py linking support for resolving soft-float symbols

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
         submodules: true
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.10'
     - uses: actions/checkout@v4
       with:
         repository: jonnor/micropython

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       with:
         repository: jonnor/micropython
         path: micropython
-        ref: emlearn-micropython-v1.23
+        ref: why-mpy-linking
     - name: Install Python dependencies
       run: pip install -r requirements.txt
     - name: Setup MicroPython X86

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       with:
         repository: jonnor/micropython
         path: micropython
-        ref: why-mpy-linking2
+        ref: why-mpy-linking3
     - name: Install Python dependencies
       run: pip install -r requirements.txt
     - name: Setup MicroPython X86

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       with:
         repository: jonnor/micropython
         path: micropython
-        ref: why-mpy-linking
+        ref: why-mpy-linking2
     - name: Install Python dependencies
       run: pip install -r requirements.txt
     - name: Setup MicroPython X86

--- a/src/emlfft/Makefile
+++ b/src/emlfft/Makefile
@@ -27,7 +27,7 @@ $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
 
-MPY_LINK_RUNTIME = 1
+MICROPY_LINK_RUNTIME = 1
 
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk

--- a/src/emlfft/Makefile
+++ b/src/emlfft/Makefile
@@ -10,7 +10,6 @@ MPY_ABI_VERSION := 6.3
 # Location of emlearn library
 EMLEARN_DIR := $(shell python3 -c "import emlearn; print(emlearn.includedir)")
 
-
 DIST_DIR := ../../dist/$(ARCH)_$(MPY_ABI_VERSION)
 
 # Name of module
@@ -18,47 +17,6 @@ MOD = emlfft
 
 # Source files (.c or .py)
 SRC = fft.c fft.py
-
-
-# Stuff to make soft-float work
-# If symbols are undefined, use tools/find_symbols.py to locate object files to add
-ifeq ($(ARCH), armv7emsp)
-	SOFTFP_O := _arm_addsubdf3.o _arm_muldivdf3.o _arm_muldivdf3.o _arm_truncdfsf2.o
-endif
-
-
-ifeq ($(ARCH), xtensawin)
-	SOFTFP_O := _floatsidf.o _muldf3.o _divdf3.o _truncdfsf2.o
-endif
-
-ifeq ($(ARCH), armv6m)
-	SOFTFP_O := mulsf3.o addsf3.o subsf3.o _clzsi2.o _udivsi3.o
-endif
-ifeq ($(ARCH), armv7m)
-	SOFTFP_O := _arm_addsubsf3.o _arm_muldivsf3.o mulsf3.o addsf3.o subsf3.o _clzsi2.o _udivsi3.o
-endif
-
-
-SOFTFP_ENABLE := 0
-ifeq ($(ARCH), armv6m)
-	SOFTFP_ENABLE=1
-endif
-ifeq ($(ARCH), armv7m)
-	SOFTFP_ENABLE=1
-endif
-
-ifeq ($(ARCH), xtensawin)
-	SOFTFP_ENABLE=1
-endif
-ifeq ($(ARCH), armv7emsp)
-	SOFTFP_ENABLE=1
-endif
-
-ifeq ($(SOFTFP_ENABLE), 1)
-	SRC_O += $(SOFTFP_O)
-	SRC_O += $(LIBM_O)
-	#CLEAN_EXTRA += $(SOFTFP_O)
-endif
 
 # Releases
 DIST_FILE = $(DIST_DIR)/$(MOD).mpy
@@ -68,36 +26,11 @@ $(DIST_DIR):
 $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
+
+MPY_LINK_RUNTIME = 1
+
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk
-
-# CROSS is defined by the included
-LIBGCC_FILENAME = $(shell $(CROSS)gcc $(CFLAGS) -print-libgcc-file-name)
-$(info $(LIBGCC_FILENAME))
-
-# FIXME: unhardcode these libm
-ifeq ($(ARCH), xtensawin)
-LIBM_FILENAME = /home/jon/.espressif/tools/xtensa-esp32-elf/esp-2022r1-11.2.0/xtensa-esp32-elf/xtensa-esp32-elf/lib/esp32-psram/no-rtti/libm.a
-endif
-
-ifeq ($(ARCH), armv7emsp)
-	LIBM_FILENAME = /usr/arm-none-eabi/lib/thumb/v7e-m+fp/hard/libm.a
-endif
-
-libm_a-sf_cos.o:
-	$(CROSS)ar -x $(LIBM_FILENAME) $(LIBM_O)
-
-lib_a-sf_cos.o:
-	$(CROSS)ar -x $(LIBM_FILENAME) $(LIBM_O)
-
-_arm_truncdfsf2.o:
-	$(CROSS)ar -x $(LIBGCC_FILENAME) $(SOFTFP_O)
-
-_truncdfsf2.o:
-	$(CROSS)ar -x $(LIBGCC_FILENAME) $(SOFTFP_O)
-
-_udivsi3.o:
-	$(CROSS)ar -x $(LIBGCC_FILENAME) $(SOFTFP_O)
 
 CFLAGS += -I$(EMLEARN_DIR)
 

--- a/src/emlfft/fft.c
+++ b/src/emlfft/fft.c
@@ -23,11 +23,6 @@ void NORETURN abort() {
 }
 #endif
 
-int
-__aeabi_idiv0(int return_value) {
-  return return_value;
-}
-
 
 // Copy of eml_fft.h, without eml_fft_fill
 // - contains sin/cos that trips up mpy_ld.py (even if the function is not used)

--- a/src/emliir/Makefile
+++ b/src/emliir/Makefile
@@ -19,23 +19,6 @@ MOD = emliir
 # Source files (.c or .py)
 SRC = iir_filter.c
 
-# Stuff to make soft-float work
-# If symbols are undefined, use tools/find_symbols.py to locate object files to add
-SOFTFP_O := _arm_cmpsf2.o lesf2.o _arm_fixsfsi.o fixsfsi.o eqsf2.o gesf2.o addsf3.o mulsf3.o subsf3.o _clzsi2.o divdf3.o
-SOFTFP_O += _dvmd_tls.o _aeabi_uldivmod.o _aeabi_ldivmod.o _divsi3.o _udivsi3.o _modsi3.o _umodsi3.o _thumb1_case_uhi.o  _udivmoddi4.o bpabi.o _clzdi2.o _ashldi3.o _lshrdi3.o _muldi3.o _divdi3.o _arm_muldivsf3.o _arm_addsubsf3.o
-SOFTFP_ENABLE := 0
-ifeq ($(ARCH), armv6m)
-	SOFTFP_ENABLE=1
-endif
-ifeq ($(ARCH), armv7m)
-	SOFTFP_ENABLE=1
-endif
-
-ifeq ($(SOFTFP_ENABLE), 1)
-	SRC_O += $(SOFTFP_O)
-	#CLEAN_EXTRA += $(SOFTFP_O)
-endif
-
 # Releases
 DIST_FILE = $(DIST_DIR)/$(MOD).mpy
 $(DIST_DIR):

--- a/src/emliir/Makefile
+++ b/src/emliir/Makefile
@@ -27,15 +27,10 @@ $(DIST_DIR):
 $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
+MPY_LINK_RUNTIME = 1
+
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk
-
-# CROSS is defined by the included
-LIBGCC_FILENAME = $(shell $(CROSS)gcc $(CFLAGS) -print-libgcc-file-name)
-$(info $(LIBGCC_FILENAME))
-
-_arm_cmpsf2.o:
-	$(CROSS)ar -x $(LIBGCC_FILENAME) $(SOFTFP_O)
 
 CFLAGS += -I$(EMLEARN_DIR)
 

--- a/src/emliir/Makefile
+++ b/src/emliir/Makefile
@@ -27,7 +27,7 @@ $(DIST_DIR):
 $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
-MPY_LINK_RUNTIME = 1
+MICROPY_LINK_RUNTIME = 1
 
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk

--- a/src/emliir/iir_filter.c
+++ b/src/emliir/iir_filter.c
@@ -19,17 +19,6 @@ void NORETURN abort() {
         ;
     }
 }
-
-int
-__aeabi_idiv0(int return_value) {
-  return return_value;
-}
-
-long long
-__aeabi_ldiv0(long long return_value) {
-  return return_value;
-}
-
 #endif
 
 

--- a/src/emlkmeans/Makefile
+++ b/src/emlkmeans/Makefile
@@ -15,23 +15,6 @@ MOD = emlkmeans
 # Source files (.c or .py)
 SRC = kmeans.c kmeans.py
 
-# Stuff to make soft-float work
-# If symbols are undefined, use tools/find_symbols.py to locate object files to add
-SOFTFP_O := _divsi3.o
-
-SOFTFP_ENABLE := 0
-ifeq ($(ARCH), armv6m)
-	SOFTFP_ENABLE=1
-endif
-ifeq ($(ARCH), armv7m)
-	SOFTFP_ENABLE=1
-endif
-
-ifeq ($(SOFTFP_ENABLE), 1)
-	SRC_O += $(SOFTFP_O)
-	#CLEAN_EXTRA += $(SOFTFP_O)
-endif
-
 # Releases
 DIST_FILE = $(DIST_DIR)/$(MOD).mpy
 $(DIST_DIR):
@@ -40,14 +23,9 @@ $(DIST_DIR):
 $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
+MPY_LINK_RUNTIME = 1
+
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk
-
-# CROSS is defined by the included dynruntime.mk
-LIBGCC_FILENAME = $(shell $(CROSS)gcc $(CFLAGS) -print-libgcc-file-name)
-$(info $(LIBGCC_FILENAME))
-
-_divsi3.o:
-	$(CROSS)ar -x $(LIBGCC_FILENAME) $(SOFTFP_O)
 
 dist: $(DIST_FILE)

--- a/src/emlkmeans/Makefile
+++ b/src/emlkmeans/Makefile
@@ -23,7 +23,7 @@ $(DIST_DIR):
 $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
-MPY_LINK_RUNTIME = 1
+MICROPY_LINK_RUNTIME = 1
 
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk

--- a/src/emlkmeans/kmeans.c
+++ b/src/emlkmeans/kmeans.c
@@ -14,10 +14,6 @@
 #define debug_printf(...) //(0)
 #endif
 
-int
-__aeabi_idiv0(int return_value) {
-  return return_value;
-}
 
 // Find which vector in @vectors that @v is closes to
 uint16_t

--- a/src/emltrees/Makefile
+++ b/src/emltrees/Makefile
@@ -28,7 +28,7 @@ $(DIST_DIR):
 $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
-MPY_LINK_RUNTIME = 1
+MICROPY_LINK_RUNTIME = 1
 
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk

--- a/src/emltrees/Makefile
+++ b/src/emltrees/Makefile
@@ -20,27 +20,6 @@ MOD = emltrees
 # Source files (.c or .py)
 SRC = trees.c trees.py
 
-# Stuff to make soft-float work
-# If symbols are undefined, use tools/find_symbols.py to locate object files to add
-SOFTFP_O := _arm_cmpsf2.o lesf2.o _arm_fixsfsi.o fixsfsi.o eqsf2.o gesf2.o _arm_addsubsf3.o _arm_muldivsf3.o addsf3.o _clzsi2.o _udivsi3.o floatsisf.o divsf3.o _thumb1_case_uqi.o
-XTENSA_SOFTFP_O := _divsf3.o
-SOFTFP_ENABLE := 0
-ifeq ($(ARCH), armv6m)
-	SOFTFP_ENABLE=1
-endif
-ifeq ($(ARCH), armv7m)
-	SOFTFP_ENABLE=1
-endif
-ifeq ($(ARCH), xtensawin)
-	SRC_O += $(XTENSA_SOFTFP_O)
-	CLEAN_EXTRA += $(XTENSA_SOFTFP_O)
-endif
-
-ifeq ($(SOFTFP_ENABLE), 1)
-	SRC_O += $(SOFTFP_O)
-	CLEAN_EXTRA += $(SOFTFP_O)
-endif
-
 # Releases
 DIST_FILE = $(DIST_DIR)/$(MOD).mpy
 $(DIST_DIR):
@@ -49,18 +28,10 @@ $(DIST_DIR):
 $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
+MPY_LINK_RUNTIME = 1
+
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk
-
-# CROSS is defined by the included
-LIBGCC_FILENAME = $(shell $(CROSS)gcc $(CFLAGS) -print-libgcc-file-name)
-$(info $(LIBGCC_FILENAME))
-
-_arm_cmpsf2.o:
-	$(CROSS)ar -x $(LIBGCC_FILENAME) $(SOFTFP_O)
-
-_divsf3.o:
-	$(CROSS)ar -x $(LIBGCC_FILENAME) $(XTENSA_SOFTFP_O)
 
 CFLAGS += -I$(EMLEARN_DIR)
 

--- a/src/emltrees/trees.c
+++ b/src/emltrees/trees.c
@@ -18,12 +18,6 @@ void *memset(void *s, int c, size_t n) {
 }
 #endif
 
-// Softfloat
-int
-__aeabi_idiv0(int return_value) {
-  return return_value;
-}
-
 
 // For building up an EmlTrees structure
 typedef struct _EmlTreesBuilder {

--- a/src/tinymaix_cnn/Makefile
+++ b/src/tinymaix_cnn/Makefile
@@ -26,7 +26,7 @@ $(DIST_DIR):
 $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
-MPY_LINK_RUNTIME = 1
+MICROPY_LINK_RUNTIME = 1
 
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk

--- a/src/tinymaix_cnn/Makefile
+++ b/src/tinymaix_cnn/Makefile
@@ -18,32 +18,6 @@ MOD = tinymaix_cnn
 # Source files (.c or .py)
 SRC = mod_cnn.c
 
-# Stuff to make soft-float work
-# If symbols are undefined, use tools/find_symbols.py to locate object files to add
-SOFTFP_O :=
-SOFTFP_ENABLE := 0
-ifeq ($(ARCH), armv6m)
-	SOFTFP_ENABLE=1
-#    SOFTFP_O += 
-endif
-ifeq ($(ARCH), armv7m)
-	SOFTFP_ENABLE=1
-    SOFTFP_O += _arm_addsubsf3.o _arm_muldivsf3.o _arm_fixsfsi.o _arm_cmpsf2.o _arm_fixunssfsi.o _arm_addsubdf3.o _arm_truncdfsf2.o
-endif
-ifeq ($(ARCH), armv7emsp)
-	SOFTFP_ENABLE=1
-    SOFTFP_O += _arm_addsubdf3.o _arm_truncdfsf2.o
-endif
-ifeq ($(ARCH), xtensawin)
-	SOFTFP_ENABLE=1
-    SOFTFP_O += _truncdfsf2.o _addsubdf3.o _extendsfdf2.o _divsf3.o
-endif
-
-ifeq ($(SOFTFP_ENABLE), 1)
-	SRC_O += $(SOFTFP_O)
-	#CLEAN_EXTRA += $(SOFTFP_O)
-endif
-
 # Releases
 DIST_FILE = $(DIST_DIR)/$(MOD).mpy
 $(DIST_DIR):
@@ -52,18 +26,10 @@ $(DIST_DIR):
 $(DIST_FILE): $(MOD).mpy $(DIST_DIR)
 	cp $< $@
 
+MPY_LINK_RUNTIME = 1
+
 # Include to get the rules for compiling and linking the module
 include $(MPY_DIR)/py/dynruntime.mk
-
-# CROSS is defined by the included
-LIBGCC_FILENAME = $(shell $(CROSS)gcc $(CFLAGS) -print-libgcc-file-name)
-$(info $(LIBGCC_FILENAME))
-
-_addsubdf3.o:
-	$(CROSS)ar -x $(LIBGCC_FILENAME) $(SOFTFP_O)
-
-_arm_addsubdf3.o:
-	$(CROSS)ar -x $(LIBGCC_FILENAME) $(SOFTFP_O)
 
 CFLAGS += -I$(TINYMAIX_DIR)/include -I$(TINYMAIX_DIR)/src -Wno-error=unused-variable -Wno-error=multichar
 


### PR DESCRIPTION
Currently utilizes an MR at https://github.com/micropython/micropython/pull/15838 - hopefully to be included in MicroPython shortly.

It lets us remove all the hacking where we manually resolve symbols, unpack archives and add them to the build.