### PR TITLE
Update to MicroPython 1.24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       with:
         repository: jonnor/micropython
         path: micropython
-        ref: emlearn-micropython-v1.23-2
+        ref: emlearn-micropython-v1.24-1
     - name: Install Python dependencies
       run: pip install -r requirements.txt
     - name: Setup MicroPython X86

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ git clone https://github.com/emlearn/emlearn-micropython
 Start with the instructions in [XOR example](./examples/xor_trees/).
 
 
+## Supported versions
+
+At any given point in time, emlearn-micropython only provides pre-built binaries for one MicroPython version.
+In general we strongly encourage people to use the latest version.
+There are no long-term-support or bugfix versions, at this point.
+If you build from source, the current version of emlearn-micropython might also work on a couple of MicroPython versions around the time, but this is not guaranteed.
+
+| MicroPython      | emlearn-micropython  |
+|------------------| ------------------   |
+| 1.24.x           | master               |
+| 1.24.x           | 0.7.0                |
+| 1.23.x           | 0.6.0                |
+
 #### Find architecture and .mpy version
 
 The correct .mpy files to use depend on the CPU architecture of your microcontroller,

--- a/examples/har_trees/README.md
+++ b/examples/har_trees/README.md
@@ -14,7 +14,7 @@ This has been used for many kinds of animals - such as cats, dogs, diary cattle.
 The same approach can be used for simple gesture recognition.
 
 ## Status
-Working. Tested running on ESP32 with MicroPython 1.23.
+Working. Tested running on ESP32 with MicroPython 1.24.
 
 **NOTE:** This is primarily *example* code for a Human Activity Recognition,
 not a generally-useful pretrained model.
@@ -34,7 +34,7 @@ The example uses the [UCI-HAR dataset](https://www.archive.ics.uci.edu/dataset/3
 The classes are by default limited to the three static postures (standing, sitting, lying) plus three dynamic activities (walking, walking downstairs, walking upstairs).
 The data is from a waist-mounted smartphone.
 Samplerate is 50Hz.
-By default only the accelerometer data is used.
+By default only the accelerometer data is used (not the gyro).
 
 
 ## TODO
@@ -48,7 +48,7 @@ By default only the accelerometer data is used.
 
 To run the example on your PC using Unix port of MicroPython.
 
-Make sure to have the Unix port of MicroPython 1.23 setup.
+Make sure to have the Unix port of MicroPython setup.
 On Windows you can use Windows Subsystem for Linux (WSL), or Docker.
 
 Download the files in this example directory
@@ -66,7 +66,7 @@ micropython har_run.py
 
 ## Running on device (Viper IDE)
 
-Make sure to have MicroPython 1.23 installed on device.
+Make sure to have MicroPython installed on device.
 
 The fastest and easiest to to install on your device is to use Viper IDE.
 This will install the library and the example code:
@@ -76,7 +76,7 @@ This will install the library and the example code:
 
 ## Run on device
 
-Make sure to have MicroPython 1.23 installed on device.
+Make sure to have MicroPython installed on device.
 
 Install the dependencies
 ```console

--- a/examples/mnist_cnn/README.md
+++ b/examples/mnist_cnn/README.md
@@ -8,7 +8,7 @@ Make sure to have Python **3.10** installed.
 At the time TinyMaix, used for CNN, only supports Tensorflow <2.14,
 which is not supported on Python 3.12 or later.
 
-Make sure to have the Unix port of MicroPython 1.23 setup.
+Make sure to have the Unix port of MicroPython setup.
 On Windows you can use Windows Subsystem for Linux (WSL), or Docker.
 
 Install the dependencies of this example:

--- a/examples/soundlevel_iir/README.md
+++ b/examples/soundlevel_iir/README.md
@@ -68,7 +68,7 @@ Please report back if you get this running on a device not listed here.
 
 Make sure to have Python 3.10+ installed.
 
-Make sure to have the Unix port of MicroPython 1.23 setup.
+Make sure to have the Unix port of MicroPython setup.
 On Windows you can use Windows Subsystem for Linux (WSL), or Docker.
 
 Install the dependencies of this example:

--- a/examples/xor_trees/README.md
+++ b/examples/xor_trees/README.md
@@ -11,7 +11,7 @@ Simple and an OK sanity check, but particularly useful.
 
 Make sure to have Python 3.10+ installed.
 
-Make sure to have the Unix port of MicroPython 1.23 setup.
+Make sure to have the Unix port of MicroPython setup.
 On Windows you can use Windows Subsystem for Linux (WSL), or Docker.
 
 ```console


### PR DESCRIPTION
MicroPython 1.24 was released a few weeks ago. https://github.com/micropython/micropython/releases/tag/v1.24.0

With this version, we can drop some of the patches we had on top of MicroPython 1.23.