### PR TITLE
Capitalization fixes in paper and bib

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,7 +1,7 @@
 
 @misc{micropython,
   author = {George, Damien P and contributors},
-  title = {MicroPython - Python for Microcontrollers},
+  title = {MicroPython - {P}ython for Microcontrollers},
   year = {2014},
   publisher = {GitHub},
   journal = {GitHub repository},
@@ -45,8 +45,8 @@
 }
 
 @misc{tflite_micro,
-  author = {Google LLC and contributors},
-  title = {tflite-micro - Tensorflow Lite for Microcontrollers},
+  author = {{Google LLC and contributors}},
+  title = {{t}flite-micro - {T}ensor{F}low {L}ite for {M}icrocontrollers},
   year = {2019},
   publisher = {GitHub},
   journal = {GitHub repository},
@@ -79,8 +79,8 @@
             Harris, Charles R. and Archibald, Anne M. and
             Ribeiro, Ant{\^o}nio H. and Pedregosa, Fabian and
             {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},
-  title   = {{{SciPy} 1.0: Fundamental Algorithms for Scientific
-            Computing in Python}},
+  title   = {{SciPy} 1.0: fundamental algorithms for scientific
+            computing in {P}ython},
   journal = {Nature Methods},
   year    = {2020},
   volume  = {17},
@@ -160,7 +160,7 @@ author={
   author       = {Ibrahim Abdelkader and
                   Yasser El{-}Sonbaty and
                   Mohamed El{-}Habrouk},
-  title        = {Openmv: {A} Python powered, extensible machine vision camera},
+  title        = {Openmv: {A} {P}ython powered, extensible machine vision camera},
   journal      = {CoRR},
   volume       = {abs/1711.10464},
   year         = {2017},
@@ -173,7 +173,7 @@ author={
 }
 
 @article{karavaev2024tinydecisiontreeclassifier,
-  title={TinyDecisionTreeClassifier: Embedded C++ library for training and applying decision trees on the edge},
+  title={TinyDecisionTreeClassifier: Embedded {C}++ library for training and applying decision trees on the edge},
   author={Karavaev, Aleksei and Hejda, Jan and Kutilek, Patrik and Volf, Petr and Sokol, Marek and Leova, Lydie},
   journal={SoftwareX},
   volume={27},
@@ -302,7 +302,7 @@ Publisher: Multidisciplinary Digital Publishing Institute},
 }
 
 @article{plauska_performance_2023,
-	title = {Performance Evaluation of C/C++, {MicroPython}, Rust and {TinyGo} Programming Languages on {ESP}32 Microcontroller},
+	title = {Performance {E}valuation of {C}/{C}++, {MicroPython}, {R}ust and {TinyGo} {P}rogramming {L}anguages on {ESP}32 {M}icrocontroller},
 	volume = {12},
 	rights = {http://creativecommons.org/licenses/by/3.0/},
 	issn = {2079-9292},
@@ -323,7 +323,7 @@ Publisher: Multidisciplinary Digital Publishing Institute},
 }
 
 @inproceedings{ionescu_investigating_2020,
-	title = {Investigating the performance of {MicroPython} and C on {ESP}32 and {STM}32 microcontrollers},
+	title = {Investigating the performance of {MicroPython} and {C} on {ESP}32 and {STM}32 microcontrollers},
 	url = {https://ieeexplore.ieee.org/abstract/document/9292199},
 	doi = {10.1109/SIITME50350.2020.9292199},
 	abstract = {Python is a programming language that is used both by entry level programmers and advanced researchers. {MicroPython} is a software implementation of Python that runs on microcontrollers. This paper will investigate the {MicroPython} execution performance compared to similar C native code on low cost microcontrollers: {STM}32 and {ESP}32. The comparison will target: memory allocation speed; {SHA}-256 and {CRC}-32 performance and will present conclusions regarding the encountered problems and ways to improve the application performance.},
@@ -340,7 +340,7 @@ Publisher: Multidisciplinary Digital Publishing Institute},
 
 @inproceedings{dokic_micropython_2020,
 	location = {Cham},
-	title = {{MicroPython} or Arduino C for {ESP}32 - Efficiency for Neural Network Edge Devices},
+	title = {{MicroPython} or {A}rduino {C} for {ESP}32 - {E}fficiency for {N}eural {N}etwork {E}dge {D}evices},
 	isbn = {978-3-030-43364-2},
 	doi = {10.1007/978-3-030-43364-2_4},
 	abstract = {In the last few years, microcontrollers used for {IoT} devices became more and more powerful, and many authors have started to use them in machine learning systems. Most of the authors used them just for data collecting for {ML} algorithms in the clouds, but some of them implemented {ML} algorithms on the microcontrollers. The goal of this paper is to analyses the neural networks data propagation speed of one popular {SoC} (Espressif System company {ESP}32) with simple neural networks implementation with two different development environment, Arduino {IDE} and {MycroPython}. Neural networks with one hidden layer are used with a different number of neurons. This {SoC} is analysed because some companies started to produce them with {UXGA} (Ultra Extended Graphics Array) camera implemented and it can be used to distribute computing load from central {ML} servers.},

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -49,7 +49,7 @@ with MicroPython can be inefficient [@plauska_performance_2023; @ionescu_investi
 This also limits the effectiveness of tools that generate Python code, such as m2cgen [@m2cgen].
 
 The library ulab [@ulab] implements efficient numeric computing facilities for MicroPython,
-including the core parts of numpy [@numpy], plus some parts of scipy [@scipy].
+including the core parts of NumPy [@numpy], plus some parts of SciPy [@scipy].
 However, as of 2025, there are no implementations of machine learning algorithms available in ulab.
 
 OpenMV [@OpenMV] is a project for machine-vision/computer-vision applications using high-end microcontrollers.
@@ -76,7 +76,7 @@ The emlearn-micropython software package provides a selection of machine learnin
 along with some functions for digital signal processing.
 The algorithms have been selected based on what is useful and commonly used in embedded systems for processing sensor data.
 The implementations are designed to be compatible with established packages,
-notably scikit-learn [@scikit-learn], Keras [@keras] and scipy [@scipy].
+notably scikit-learn [@scikit-learn], Keras [@keras] and SciPy [@scipy].
 \autoref{table_emlearn_micropython_modules} provides a listing of the provided functionality.
 
 The software is distributed as MicroPython native modules [@micropython_native_module],


### PR DESCRIPTION
ref: openjournals/joss-reviews#9093

* Some capitalization style fixes, e.g., numpy &rarr; NumPy, c++ &rarr; C++, …
* Otherwise: changed title capitalization to match the style of the cited work, e.g., scipy bib entry.
